### PR TITLE
Add basic Flask dashboard for DISARM data

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,59 @@
+from flask import Flask, render_template
+import zipfile
+import xml.etree.ElementTree as ET
+
+APP_XLSX = 'DISARM_MASTER_DATA/DISARM_FRAMEWORKS_MASTER.xlsx'
+NAMESPACE = {'ns': 'http://schemas.openxmlformats.org/spreadsheetml/2006/main'}
+
+app = Flask(__name__)
+
+
+def read_sheet(path, sheet_id):
+    """Return sheet data as list of rows (lists of values)."""
+    with zipfile.ZipFile(path) as z:
+        # load shared strings
+        shared = []
+        if 'xl/sharedStrings.xml' in z.namelist():
+            root = ET.fromstring(z.read('xl/sharedStrings.xml'))
+            for si in root.findall('ns:si', NAMESPACE):
+                text = ''.join(el.text or '' for el in si.findall('.//ns:t', NAMESPACE))
+                shared.append(text)
+        sheet_xml = f'xl/worksheets/sheet{sheet_id}.xml'
+        sheet_root = ET.fromstring(z.read(sheet_xml))
+        data = []
+        for row in sheet_root.findall('.//ns:row', NAMESPACE):
+            row_data = []
+            for c in row.findall('ns:c', NAMESPACE):
+                v = c.find('ns:v', NAMESPACE)
+                if v is None:
+                    value = ''
+                else:
+                    value = v.text
+                    if c.attrib.get('t') == 's':
+                        value = shared[int(value)]
+                row_data.append(value)
+            data.append(row_data)
+        return data
+
+
+def load_data():
+    # According to workbook.xml, sheet6 is "techniques" and sheet10 is "countermeasures"
+    red_raw = read_sheet(APP_XLSX, 6)
+    blue_raw = read_sheet(APP_XLSX, 10)
+
+    red_header = red_raw[0]
+    blue_header = blue_raw[0]
+
+    red = [dict(zip(red_header, row)) for row in red_raw[1:] if any(row)]
+    blue = [dict(zip(blue_header, row)) for row in blue_raw[1:] if any(row)]
+    return red, blue
+
+
+@app.route('/')
+def index():
+    red, blue = load_data()
+    return render_template('index.html', red=red, blue=blue)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>DISARM Dashboard</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .container { display: flex; }
+        .column { width: 50%; padding: 10px; }
+        table { border-collapse: collapse; width: 100%; }
+        th, td { border: 1px solid #ccc; padding: 4px; text-align: left; }
+        th { background: #eee; }
+    </style>
+</head>
+<body>
+    <h1>DISARM Framework Dashboard</h1>
+    <div class="container">
+        <div class="column">
+            <h2>Red Team TTPs</h2>
+            <table>
+                <tr>
+                    <th>ID</th>
+                    <th>Name</th>
+                    <th>Tactic</th>
+                </tr>
+                {% for item in red %}
+                <tr>
+                    <td>{{ item.disarm_id }}</td>
+                    <td>{{ item.name }}</td>
+                    <td>{{ item.tactic_id }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+        </div>
+        <div class="column">
+            <h2>Blue Team Countermeasures</h2>
+            <table>
+                <tr>
+                    <th>ID</th>
+                    <th>Name</th>
+                    <th>Tactic</th>
+                </tr>
+                {% for item in blue %}
+                <tr>
+                    <td>{{ item.disarm_id }}</td>
+                    <td>{{ item.name }}</td>
+                    <td>{{ item.tactic }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide a small Flask app that parses DISARM Excel data without external deps
- show Red Team and Blue Team TTPs side by side in an HTML template

## Testing
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6878acff525083278574e09995273197